### PR TITLE
Fix MAL errors related to missing meta for shows

### DIFF
--- a/plugin.video.otaku/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
+++ b/plugin.video.otaku/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
@@ -93,10 +93,12 @@ class WatchlistFlavorBase(object):
 
         if show:
             anilist_id = show['anilist_id']
+            show_meta = database.get_show_meta(anilist_id)
 
-            art = pickle.loads(database.get_show_meta(anilist_id).get('art'))
-            if art.get('fanart'):
-                next_up_meta['image'] = random.choice(art.get('fanart'))
+            if show_meta:
+                art = pickle.loads(show_meta.get('art'))
+                if art.get('fanart'):
+                    next_up_meta['image'] = random.choice(art.get('fanart'))
 
             episodes = database.get_episode_list(show['anilist_id'])
             if episodes:


### PR DESCRIPTION
When browsing the "Next Up" MAL list sometimes the following error appears:

2022-10-17 03:25:39.052 T:118705   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
	 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
	 Error Type: <class 'AttributeError'>
	 Error Contents: 'NoneType' object has no attribute 'get'
	 Traceback (most recent call last):
	 File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/default.py", line 862, in <module>
        router_process(control.get_plugin_url(), control.get_plugin_params())
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/ui/router.py", line 70, in router_process
        return route_obj.func(payload, params)
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistIntegration.py", line 60, in WATCHLIST_STATUS_TYPE
        return control.draw_items(WatchlistFlavor.watchlist_status_request(flavor, status, params))
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistFlavor/__init__.py", line 59, in watchlist_status_request
        return WatchlistFlavor.__instance_flavor(name).get_watchlist_status(status, next_up)
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistFlavor/MyAnimeList.py", line 125, in get_watchlist_status
        return self._process_status_view(url, params, next_up, "watchlist_status_type_pages/mal/%s/%%s/%%d" % status, page)
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistFlavor/MyAnimeList.py", line 153, in _process_status_view
        all_results = list(map(self._base_next_up_view, results['data']))
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistFlavor/MyAnimeList.py", line 240, in _base_next_up_view
        anilist_id, next_up_meta = self._get_next_up_meta(mal_id, int(progress))
     File "/var/mobile/Library/Preferences/Kodi/addons/plugin.video.otaku/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py", line 97, in _get_next_up_meta
        art = pickle.loads(database.get_show_meta(anilist_id).get('art'))
     AttributeError: 'NoneType' object has no attribute 'get'
-->End of Python script error report<--

The proposed changes fix the issue by first making sure there's metadata in the database for the giving show before attempting to retrieve any kind of artwork from it.