### PR TITLE
Episode Aired date not showing in Next Up #54 

### DIFF
--- a/plugin.video.otaku/resources/lib/WatchlistFlavor/AniList.py
+++ b/plugin.video.otaku/resources/lib/WatchlistFlavor/AniList.py
@@ -346,7 +346,7 @@ class AniListWLF(WatchlistFlavorBase):
         base_title = res['title'].get(self._title_lang) or res['title'].get('userPreferred')
         title = '%s - %s/%s' % (base_title, next_up, episode_count)
         poster = image = res['coverImage']['extraLarge']
-        plot = None
+        plot = aired = None
 
         if episode_count > 0 and next_up > episode_count:
             return None
@@ -362,6 +362,7 @@ class AniListWLF(WatchlistFlavorBase):
             if next_up_meta.get('image'):
                 image = next_up_meta.get('image')
             plot = next_up_meta.get('plot')
+            aired = next_up_meta.get('aired')
 
         info = {}
 
@@ -371,14 +372,11 @@ class AniListWLF(WatchlistFlavorBase):
             pass
 
         info['episode'] = next_up
-
         info['title'] = title
-
         info['tvshowtitle'] = res['title']['userPreferred']
-
         info['plot'] = plot
-
         info['mediatype'] = 'episode'
+        info['aired'] = aired
 
         base = {
             "name": title,

--- a/plugin.video.otaku/resources/lib/WatchlistFlavor/Kitsu.py
+++ b/plugin.video.otaku/resources/lib/WatchlistFlavor/Kitsu.py
@@ -206,7 +206,7 @@ class KitsuWLF(WatchlistFlavorBase):
         episode_count = eres["attributes"]['episodeCount'] if eres["attributes"]['episodeCount'] is not None else 0
         title = '%s - %d/%d' % (anime_title, next_up, episode_count)
         poster = image = eres["attributes"]['posterImage']['large']
-        plot = None
+        plot = aired = None
 
         anilist_id, next_up_meta = self._get_next_up_meta(mal_id, int(progress))
         if next_up_meta:
@@ -216,18 +216,15 @@ class KitsuWLF(WatchlistFlavorBase):
             if next_up_meta.get('image'):
                 image = next_up_meta.get('image')
             plot = next_up_meta.get('plot')
-
+            aired = next_up_meta.get('aired')
         info = {}
 
         info['episode'] = next_up
-
         info['title'] = title
-
         info['tvshowtitle'] = anime_title
-
         info['plot'] = plot
-
         info['mediatype'] = 'episode'
+        info['aired'] = aired
 
         base = {
             "name": title,

--- a/plugin.video.otaku/resources/lib/WatchlistFlavor/MyAnimeList.py
+++ b/plugin.video.otaku/resources/lib/WatchlistFlavor/MyAnimeList.py
@@ -238,7 +238,7 @@ class MyAnimeListWLF(WatchlistFlavorBase):
             base_title = res['node'].get('alternative_titles').get('en') or base_title
         title = '%s - %s/%s' % (base_title, next_up, episode_count)
         poster = image = res['node']['main_picture'].get('large', res['node']['main_picture']['medium'])
-        plot = None
+        plot = aired = None
 
         anilist_id, next_up_meta = self._get_next_up_meta(mal_id, int(progress))
         if next_up_meta:
@@ -248,20 +248,18 @@ class MyAnimeListWLF(WatchlistFlavorBase):
             if next_up_meta.get('image'):
                 image = next_up_meta.get('image')
             plot = next_up_meta.get('plot')
+            aired = next_up_meta.get('aired')
 
         info = {}
 
         info['episode'] = next_up
-
         info['title'] = title
-
         info['tvshowtitle'] = res['node']['title']
-
         info['duration'] = res['node']['average_episode_duration']
-
         info['plot'] = plot
-
         info['mediatype'] = 'episode'
+        info['aired'] = aired
+        
 
         base = {
             "name": title,

--- a/plugin.video.otaku/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
+++ b/plugin.video.otaku/resources/lib/WatchlistFlavor/WatchlistFlavorBase.py
@@ -114,6 +114,7 @@ class WatchlistFlavorBase(object):
                     next_up_meta['title'] = episode_meta['info']['title']
                     next_up_meta['image'] = episode_meta['image']['thumb']
                     next_up_meta['plot'] = episode_meta['info']['plot']
+                    next_up_meta['aired'] = episode_meta['info']['aired']
                 except:
                     pass
 


### PR DESCRIPTION
This should fix the issue with next up aired dates.
I only tested this on MyAnimeList because that is what I have.
Please test it for kitsu and anilist and let me know if it works.