### PR TITLE
Add Feature to filter by release title

### DIFF
--- a/plugin.video.otaku/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.otaku/resources/language/resource.language.en_gb/strings.po
@@ -1095,6 +1095,45 @@ msgctxt "#40530"
 msgid "Disable connection error notifications?"
 msgstr ""
 
+msgctxt "#40531"
+msgid "Source Filtering by Release Title"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Filter Selection"
+msgstr ""
+
+msgctxt "#40533"
+msgid "Release Title Filter 1"
+msgstr ""
+
+msgctxt "#40534"
+msgid "Release Title Filter 2"
+msgstr ""
+
+msgctxt "#40535"
+msgid "Release Title Filter 3"
+msgstr ""
+
+msgctxt "#40536"
+msgid "Release Title Filter 4"
+msgstr ""
+
+msgctxt "#40537"
+msgid "Release Title Filter 5"
+msgstr ""
+
+msgctxt "#40538"
+msgid "Filter Logic for Multiple Filters"
+msgstr ""
+
+msgctxt "#40539"
+msgid "AND"
+msgstr ""
+
+msgctxt "#40540"
+msgid "OR"
+msgstr ""
 ######MAIN Category DIRECTORY#######
 msgctxt "#50000"
 msgid "Airing Anime Calendar"

--- a/plugin.video.otaku/resources/lib/pages/__init__.py
+++ b/plugin.video.otaku/resources/lib/pages/__init__.py
@@ -379,6 +379,21 @@ class Sources(DisplayWindow):
 
             torrent_list = [i for i in _torrent_list if i['size'] != 'NA' and min_GB <= float(i['size'][:-3]) <= max_GB]
 
+        if control.getSetting('general.release_title_filter.enabled') == 'true':
+            release_title_filter1 = control.getSetting('general.release_title_filter.value1')
+            release_title_filter2 = control.getSetting('general.release_title_filter.value2')
+            release_title_filter3 = control.getSetting('general.release_title_filter.value3')
+            release_title_filter4 = control.getSetting('general.release_title_filter.value4')
+            release_title_filter5 = control.getSetting('general.release_title_filter.value5')
+            _torrent_list = torrent_list
+            release_title_logic = control.getSetting('general.release_title_filter.logic')
+            if release_title_logic == '0':
+                # AND filter
+                torrent_list = [i for i in _torrent_list if release_title_filter1 in i['release_title'] and release_title_filter2 in i['release_title'] and release_title_filter3 in i['release_title'] and release_title_filter4 in i['release_title'] and release_title_filter5 in i['release_title']]
+            if release_title_logic == '1':
+                # OR filter
+                torrent_list = [i for i in _torrent_list if (release_title_filter1 != "" and release_title_filter1 in i['release_title']) or (release_title_filter2 != "" and release_title_filter2 in i['release_title']) or (release_title_filter3 != "" and release_title_filter3 in i['release_title']) or (release_title_filter4 != "" and release_title_filter4 in i['release_title']) or (release_title_filter5 != "" and release_title_filter5 in i['release_title'])]
+
         # Get the value of the 'sourcesort.menu' setting
         sort_option = control.getSetting('general.sourcesort')
 

--- a/plugin.video.otaku/resources/settings.xml
+++ b/plugin.video.otaku/resources/settings.xml
@@ -183,6 +183,15 @@
     	<setting id="general.movie.minGB" type="slider" subsetting="true" label="40492" option="int" default="0" range="0,100" visible="eq(-3, 2)" />
     	<setting id="general.episode.maxGB" type="slider" subsetting="true" label="40493" option="int" default="10" range="0,100" visible="eq(-4, 2)" />
     	<setting id="general.episode.minGB" type="slider" subsetting="true" label="40494" option="int" default="0" range="0,100" visible="eq(-5, 2)" />
+		<setting id="general.release_title_filter.enabled" type="bool" label="40531" default="false" />
+		<setting id="general.release_title_filter.selection" type="enum" subsetting="true" label="40532" lvalues="40533|40534|40535|40536|40537" default="0" visible="eq(-1,true)" />
+		<setting id="general.release_title_filter.logic" type="enum" subsetting="true" label="40538" lvalues="40539|40540" default="0" visible="eq(-2,true)" />
+		<setting id="general.release_title_filter.value1" type="text" subsetting="true" label="40533" default="" visible="eq(-2,0) + eq(-3,true)" />
+		<setting id="general.release_title_filter.value2" type="text" subsetting="true" label="40534" default="" visible="eq(-3,1) + eq(-4,true)" />
+		<setting id="general.release_title_filter.value3" type="text" subsetting="true" label="40535" default="" visible="eq(-4,2) + eq(-5,true)" />
+		<setting id="general.release_title_filter.value4" type="text" subsetting="true" label="40536" default="" visible="eq(-5,3) + eq(-6,true)" />
+		<setting id="general.release_title_filter.value5" type="text" subsetting="true" label="40537" default="" visible="eq(-6,4) + eq(-7,true)" />
+
 		<setting type="sep" />
 		<!-- Manual File Selection -->
 		<setting type="lsep" label="40481"/>


### PR DESCRIPTION
This aims to implement the feature request discussed in [Issue 228](https://github.com/Goldenfreddy0703/Otaku/issues/228) by adding a new setting to filter torrents by release title with options for logical AND and OR filtering and up to 5 filters to define.

Any suggestions on how to improve this are welcome.

I was thinking about having these filters per show but I don't know if it's possible to implement that.

