### PR TITLE
Small fix for the sync

### DIFF
--- a/plugin.video.otaku/resources/lib/indexers/syncurl.py
+++ b/plugin.video.otaku/resources/lib/indexers/syncurl.py
@@ -14,5 +14,6 @@ class SyncUrl:
         }
         r = database.get(client.request, 2, self.BaseURL, params=params)
         if r:
-            res = json.loads(r)
+            r_json = json.dumps(r)  # Convert response content to JSON string
+            res = json.loads(r_json)  # Parse JSON string
             return res


### PR DESCRIPTION
small bug i noticed if you left Kodi open for several days, on pc anyways please test this.

It seems that the client.request function was returning a dictionary object instead of a string, bytes, or bytearray object, which was causing the json.loads() function to raise the TypeError.

example
info <general>: @@@@Otaku log:
Request-Error: (local variable 'response' referenced before assignment) => https://find-my-anime.dtimur.de/api?id=158709&provider=Anilist&includeAdult=true

Error Type: <class 'TypeError'>
Error Contents: the JSON object must be str, bytes or bytearray, not dict

File "\plugin.video.otaku\resources\lib\indexers\syncurl.py", line 17, in get_anime_data res = json.loads(r)


To resolve this issue, we'll modify the client.request function to return the response content as a string, bytes, or bytearray object that can be parsed by json.loads().

we'll use the json.dumps() function to convert the response content to a JSON string, and then return that string.