### PR TITLE
feat(torbox): add support for torbox

### DIFF
--- a/plugin.video.otaku/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.otaku/resources/language/resource.language.en_gb/strings.po
@@ -1679,3 +1679,18 @@ msgstr ""
 msgctxt "#50096"
 msgid "TV Shows - Genre Items"
 msgstr ""
+
+msgctxt "#50097"
+msgid "Enable Torbox"
+msgstr ""
+
+msgctxt "#50098"
+msgid "Torbox API key"
+msgstr ""
+
+msgctxt "#50099"
+msgid "Torbox Priority"
+msgstr ""
+
+msgctxt "#50100"
+msgid "Scrape Torbox Cloud"

--- a/plugin.video.otaku/resources/lib/debrid/torbox.py
+++ b/plugin.video.otaku/resources/lib/debrid/torbox.py
@@ -1,0 +1,88 @@
+import json
+from resources.lib.ui import control, client, source_utils
+
+class Torbox:
+    def __init__(self):
+        self.apikey = control.getSetting('tb.apikey')
+        self.headers = {
+            'Authorization': 'Bearer {}'.format(self.apikey)
+        }
+        
+    def get_url(self, url):
+        if self.headers['Authorization'] == 'Bearer ':
+            return None
+        url = 'https://api.torbox.app/v1/api{}'.format(url)
+        req = client.request(url, timeout=10, headers=self.headers, error=True, method='GET')
+        return json.loads(req)
+    
+    def post_url(self, url, data, jpost = False):
+        if self.headers['Authorization'] == 'Bearer ':
+            return None
+        url = 'https://api.torbox.app/v1/api{}'.format(url)
+        req = client.request(url, headers=self.headers, post=data, error=True, method='POST', jpost=jpost)
+        return json.loads(req)
+
+    
+    def hash_check(self, hashList):
+        url = '/torrents/checkcached?format=list{}'
+        hashes = ','.join(hashList)
+        response = self.get_url(url.format('&hash=' + hashes))
+        response['data'] = list(map(lambda x: x['hash'], response['data']))
+        return response
+    
+    def add_magnet(self, magnet):
+        url = '/torrents/createtorrent'
+        response = self.post_url(url, { 'magnet': magnet })
+        return response['data']
+    
+    def remove_torrent(self, torrentId):
+        url = '/torrents/controltorrent'
+        data = {
+            'torrent_id': str(torrentId),
+            'operation': 'delete'
+        }
+        response = self.post_url(url, data, True)
+        return response
+    
+    def list_torrents(self):
+        url = '/torrents/mylist'
+        response = self.get_url(url)
+        return response['data']
+    
+    def get_torrent_info(self, torrentId):
+        url = '/torrents/mylist?id={}'.format(torrentId)
+        response = self.get_url(url)
+        return response['data']
+
+    def request_dl_link(self, torrentId, fileId=-1):
+        url = '/torrents/requestdl?token={token}&torrent_id={torrentId}'.format(
+            token = self.apikey, torrentId = torrentId
+        )
+
+        if fileId >= 0:
+            url = url + '&file_id=' + str(fileId)
+
+        response = self.get_url(url)
+        return response['data']
+
+    def resolve_single_magnet(self, hash_, magnet, episode='', pack_select=False):
+        torrent = self.add_magnet(magnet)
+        torrentId = torrent['torrent_id']
+        info = self.get_torrent_info(torrentId)
+        folder_details = info['files']
+        folder_details = [{ 'fileId': x['id'], 'path': x['name'] } for x in folder_details]
+        
+        if episode or pack_select:
+            selected_file = source_utils.get_best_match('path', folder_details, episode, pack_select)
+            if selected_file and selected_file['fileId'] is not None:
+                stream_link = self.request_dl_link(torrentId, selected_file['fileId'])
+                self.remove_torrent(torrentId)
+                return stream_link
+            
+        selected_file = folder_details[0]
+        if selected_file is None:
+            return
+        
+        stream_link = self.request_dl_link(torrentId, selected_file['fileId'])
+        self.remove_torrent(torrentId)
+        return stream_link

--- a/plugin.video.otaku/resources/lib/pages/__init__.py
+++ b/plugin.video.otaku/resources/lib/pages/__init__.py
@@ -115,7 +115,7 @@ class Sources(DisplayWindow):
         control.setSetting('hianime.skipoutro.start', '-1')
         control.setSetting('hianime.skipoutro.end', '-1')
 
-        if control.real_debrid_enabled() or control.all_debrid_enabled() or control.debrid_link_enabled() or control.premiumize_enabled():
+        if control.real_debrid_enabled() or control.all_debrid_enabled() or control.debrid_link_enabled() or control.premiumize_enabled() or control.torbox_enabled():
             if control.getSetting('provider.nyaa') == 'true':
                 self.threads.append(
                     threading.Thread(target=self.nyaa_worker, args=(query, anilist_id, episode, status, media_type, rescrape)))
@@ -345,6 +345,9 @@ class Sources(DisplayWindow):
             if control.all_debrid_enabled() and control.getSetting('alldebrid.cloudInspection') == 'true':
                 debrid['all_debrid'] = True
 
+            if control.torbox_enabled() and control.getSetting('tb.cloudInspection') == 'true':
+                debrid['torbox'] = True
+
             self.usercloudSources = debrid_cloudfiles.sources().get_sources(debrid, query, episode)
             self.cloud_files += self.usercloudSources
 
@@ -382,6 +385,8 @@ class Sources(DisplayWindow):
             p.append({'slug': 'all_debrid', 'priority': int(control.getSetting('alldebrid.priority'))})
         if control.getSetting('dl.enabled') == 'true':
             p.append({'slug': 'debrid_link', 'priority': int(control.getSetting('dl.priority'))})
+        if control.getSetting('tb.enabled') == 'true':
+            p.append({'slug': 'torbox', 'priority': int(control.getSetting('tb.priority'))})
 
         p.append({'slug': '', 'priority': 11})
 

--- a/plugin.video.otaku/resources/lib/ui/control.py
+++ b/plugin.video.otaku/resources/lib/ui/control.py
@@ -114,6 +114,10 @@ def premiumize_enabled():
     return True if getSetting('premiumize.token') != '' and getSetting('premiumize.enabled') == 'true' else False
 
 
+def torbox_enabled():
+    return True if getSetting('tb.apikey') != '' and getSetting('tb.enabled') == 'true' else False
+
+
 def myanimelist_enabled():
     return True if getSetting('mal.token') != '' and getSetting('mal.enabled') == 'true' else False
 

--- a/plugin.video.otaku/resources/settings.xml
+++ b/plugin.video.otaku/resources/settings.xml
@@ -359,7 +359,7 @@
 		<!-- Torbox-->
 		<setting type="lsep" label="Torbox" />
 		<setting type="sep" />
-		<setting id="torbox.enabled" type="bool" default="false" label="50097" />
+		<setting id="tb.enabled" type="bool" default="false" label="50097" />
 		<setting id="tb.apikey" type="text" label="50098" default="" enable="true" visible="eq(-1,true)" />
 		<setting id="tb.priority" type="slider" subsetting="true" label="50099" option="int" range="1,1,10" default="10" visible="eq(-2,true)" />
 	</category>

--- a/plugin.video.otaku/resources/settings.xml
+++ b/plugin.video.otaku/resources/settings.xml
@@ -225,6 +225,7 @@
 		<setting id="rd.cloudInspection" type="bool" label="40547" default="false" />
 		<setting id="premiumize.cloudInspection" type="bool" label="40548" default="false" />
 		<setting id="alldebrid.cloudInspection" type="bool" label="40583" default="false" />
+		<setting id="tb.cloudInspection" type="bool" label="50100" default="false" />
 
 		<!-- Local Scraping -->
 		<setting type="lsep" label="40546"/>
@@ -354,6 +355,13 @@
 		<setting id="rd.username" type="text" label="40337" default="" enable="false" visible="eq(-1,true)" />
 		<setting id="rd.auth_start" type="action" label="40338" option="close" action="RunPlugin(plugin://plugin.video.otaku/authRealDebrid)" visible="eq(-2,true)" />
 		<setting id="rd.priority" type="slider" subsetting="true" label="40339" option="int" range="1,1,10" default="10" visible="eq(-3,true)" />
+
+		<!-- Torbox-->
+		<setting type="lsep" label="Torbox" />
+		<setting type="sep" />
+		<setting id="torbox.enabled" type="bool" default="false" label="50097" />
+		<setting id="tb.apikey" type="text" label="50098" default="" enable="true" visible="eq(-1,true)" />
+		<setting id="tb.priority" type="slider" subsetting="true" label="50099" option="int" range="1,1,10" default="10" visible="eq(-2,true)" />
 	</category>
 
 	<!-- Watchlist -->


### PR DESCRIPTION
**Background:**

Due to the recent restrictions applied to Real Debrid & AllDebrid, a part of the community is switching to Torbox as their preferred debrid service as seen in #369. This PR is adding a basic implementation of Torbox including cloud inspection.

**Solution:**
- Added settings for torbox
   - Enable Torbox
   - Torbox API key
   - Torbox Priority
- Add torbox as debrid service
   - Implementation is still quite basic but works for the necessary cases
- Add torbox cloud inspection
   - Using user select to find the best matching file name 
- Add snippets for en_GB