### PR TITLE
Fix playback issues with Real Debrid, Nyaa, and Animetosho links

### DIFF
--- a/plugin.video.otaku/resources/lib/Main.py
+++ b/plugin.video.otaku/resources/lib/Main.py
@@ -1727,6 +1727,9 @@ def PLAY(payload, params):
     # This ensures metadata is available even when playing from Information dialog
     if not params.get('tvshowtitle'):
         episode_data = database.get_episode(mal_id, episode)
+        if not episode_data:
+            MetaBrowser.get_anime_init(mal_id)
+            episode_data = database.get_episode(mal_id, episode)
         if episode_data:
             params = pickle.loads(episode_data['kodi_meta'])
 


### PR DESCRIPTION
 Hey! I noticed that watching links from sources like Real Debrid, Nyaa, or Animetosho was broken in some cases because the local database was missing the necessary episode metadata.

I fixed this by adding a check: if episode_data comes back empty when trying to play, it now calls MetaBrowser.get_anime_init(mal_id) to force a refresh/initialization of the anime data. After that, it re-fetches the episode data, which ensures we have the correct metadata params to proceed with playback.

I've tested this locally and it resolves the issue.

I also had another issue with where https://animeschedule.net/api/v3/anime call was returning 429 Too Many Requests status codes if I had too many "next up" animes (I use anilist). The fix was to just move my anime to "plan to watch", however I wondered if reducing parallel workers might fix it, [the api docs for the endpoint ](https://animeschedule.net/api/v3/documentation/anime) mention it supports multiple ids, however after testing it, that doesn't really work.

For context: I work as a python developer, first time trying to fix a kodi plugin. I use your plugin heavily, if you need help/want to refactor anything feel free to shoot me a message (like switching to requests library for API calls instead of your own client).