### PR TITLE
Fix AllDebrid cloud scraping: scan magnets, saved links and history

### DIFF
--- a/plugin.video.otaku/resources/lib/debrid/all_debrid.py
+++ b/plugin.video.otaku/resources/lib/debrid/all_debrid.py
@@ -114,12 +114,35 @@ class AllDebrid:
         r = client.get(f'{self.base_url}/magnet/status', params=params)
         return r.json()['data'] if r else None
 
-    def list_torrents(self):
+    def list_saved_links(self):
         params = {
             'agent': self.agent_identifier,
             'apikey': self.token
         }
         r = client.get(f'{self.base_url}/user/links', params=params)
+        return r.json()['data'] if r else None
+
+    def list_torrents(self):
+        params = {
+            'agent': self.agent_identifier,
+            'apikey': self.token,
+            'status': 'ready'
+        }
+        r = client.get(f'{self.base_url}/magnet/status', params=params)
+        data = r.json()['data'] if r else None
+        if not data:
+            return []
+        magnets = data['magnets']
+        if isinstance(magnets, dict):
+            magnets = list(magnets.values())
+        return magnets
+
+    def list_history(self):
+        params = {
+            'agent': self.agent_identifier,
+            'apikey': self.token
+        }
+        r = client.get(f'{self.base_url}/user/history', params=params)
         return r.json()['data'] if r else None
 
     def link_info(self, link):

--- a/plugin.video.otaku/resources/lib/pages/debrid_cloudfiles.py
+++ b/plugin.video.otaku/resources/lib/pages/debrid_cloudfiles.py
@@ -143,23 +143,47 @@ class Sources(BrowserBase):
 
     def alldebrid_cloud_inspection(self, query, mal_id, episode, season=None):
         api = all_debrid.AllDebrid()
-        torrents = api.list_torrents()['links']
+        torrents = api.list_torrents()
+        for saved in (api.list_saved_links(), api.list_history()):
+            if saved and saved.get('links'):
+                torrents += saved['links']
+        seen = set()
+        torrents = [t for t in torrents if t.get('filename') and not (t['filename'] in seen or seen.add(t['filename']))]
         torrents = source_utils.filter_sources('alldebrid', torrents, mal_id, season, episode)
         filenames = [re.sub(r'\[.*?]\s*', '', i['filename'].replace(',', '')) for i in torrents]
         resp = source_utils.get_fuzzy_match(query, filenames)
 
         for i in resp:
             torrent = torrents[i]
-            torrent_info = api.link_info(torrent['link'])
-            torrent_files = torrent_info['infos']
+            if torrent.get('link'):
+                if not source_utils.is_file_ext_valid(torrent['filename'].lower()):
+                    continue
+                url = api.resolve_hoster(torrent['link'])
+            else:
+                status_data = api.magnet_status(torrent['id'])
+                if not status_data or 'magnets' not in status_data or 'files' not in status_data['magnets']:
+                    continue
 
-            if len(torrent_files) > 1 and len(torrent_info['links']) == 1:
+                folder_details = []
+                for x in status_data['magnets']['files']:
+                    api.collect_files(x, folder_details)
+                folder_details = [f for f in folder_details if source_utils.is_file_ext_valid(f['path'].lower())]
+
+                if not folder_details:
+                    continue
+
+                selected_file = folder_details[0]
+                if len(folder_details) > 1 and episode:
+                    regex = source_utils.get_cache_check_reg(episode)
+                    ep_matches = [f for f in folder_details if regex.search(f['path'].split('/')[-1])]
+                    if ep_matches:
+                        selected_file = ep_matches[0]
+
+                url = api.resolve_hoster(selected_file['link'])
+
+            if not url:
                 continue
 
-            if not any(source_utils.is_file_ext_valid(tor_file['filename'].lower()) for tor_file in torrent_files):
-                continue
-
-            url = api.resolve_hoster(torrent['link'])
             self.cloud_files.append(
                 {
                     'quality': source_utils.getQuality(torrent['filename']),

--- a/plugin.video.otaku/resources/lib/ui/source_utils.py
+++ b/plugin.video.otaku/resources/lib/ui/source_utils.py
@@ -500,8 +500,7 @@ def filter_sources(provider, torrent_list, mal_id, season=None, episode=None, pa
         elif provider == 'realdebrid':
             torrent['hash'] = torrent.get('hash', '')
         elif provider == 'alldebrid':
-            link = torrent['link']
-            torrent['hash'] = re.search(r'/f/([^/]+)', link).group(1)
+            torrent['hash'] = torrent.get('hash', '')
         elif provider == 'premiumize':
             torrent['hash'] = torrent.get('id', '')
         elif provider == 'torbox':


### PR DESCRIPTION
The "Scrape AllDebrid Cloud" feature never returned any torrent stored in the user's AllDebrid cloud.

### Problem
`alldebrid_cloud_inspection` called `AllDebrid.list_torrents()`, which actually queries `/user/links` — i.e. the manually **saved links**, not the user's torrents. Torrents added to the cloud (magnets) were therefore never inspected. On top of that, `filter_sources` crashed for the `alldebrid` provider:

```python
torrent["hash"] = re.search(r"/f/([^/]+)", link).group(1)
```

Saved links can be plain hoster URLs (e.g. `mega.co.nz`) with no `/f/` segment, so `re.search` returned `None` and `.group(1)` raised `AttributeError`. That exception propagated through `get_sources()`, discarding every cloud provider's results and leaving the scrape to run until timeout.

### Fix
The AllDebrid cloud inspection now scans the **three** AllDebrid cloud sources and merges them, deduplicated by filename:

- **magnets** — `/magnet/status?status=ready`
- **saved links** — `/user/links`
- **unlock history** — `/user/history`

Magnet files are resolved through the existing `magnet_status` + `collect_files` helpers (with episode matching for packs); direct links are resolved straight through `resolve_hoster`.

`filter_sources` now uses `torrent.get("hash", "")` for `alldebrid`, identical to the `realdebrid`/`torbox` branches (magnets expose a real infohash), so it no longer crashes on any link shape.

### Method renames (AllDebrid only)
- `list_torrents` → `list_saved_links` (it returns `/user/links`)
- new magnet listing → `list_torrents` (so `AllDebrid().list_torrents()` matches the Real-Debrid/TorBox interface)
- added `list_history`

Real-Debrid and TorBox `list_torrents()` calls are untouched.

### Testing
Verified live against an AllDebrid account: a movie present only as a magnet, an episode present only in history, and a saved link all resolve to a playable link; duplicates shared between magnets and history are removed.