### PR TITLE
Initial Commit, Base Path Shared Variable & Tenrai Migration

### DIFF
--- a/plugin.video.otaku/resources/lib/MalBrowser.py
+++ b/plugin.video.otaku/resources/lib/MalBrowser.py
@@ -37,7 +37,7 @@ _MAL_GENRE_PRESETS = (
 
 
 class MalBrowser(BrowserBase):
-    _BASE_URL = "https://api.jikan.moe/v4"
+    _BASE_URL = control.MAL_API_BASE_URL
 
     _IX_YEAR_START = 2
     _IX_YEAR_END = 3

--- a/plugin.video.otaku/resources/lib/OtakuBrowser.py
+++ b/plugin.video.otaku/resources/lib/OtakuBrowser.py
@@ -38,7 +38,7 @@ _MAL_GENRE_PRESETS = (
 
 
 class OtakuBrowser(BrowserBase):
-    _BASE_URL = "https://api.jikan.moe/v4"
+    _BASE_URL = control.MAL_API_BASE_URL
 
     # Indices returned by get_season_year()
     _IX_YEAR_START = 2
@@ -74,6 +74,11 @@ class OtakuBrowser(BrowserBase):
         """Normalize direct items and nested/list 'entry' shapes (e.g. relations)."""
         mal_items_flat = []
         mal_ids = []
+        if not mal_res:
+            # Upstream API call failed (timeout, 5xx, rate limit) and returned
+            # None instead of a response body - fail soft instead of crashing.
+            control.log("MAL API request failed or returned no data", 'warning')
+            return mal_ids, mal_items_flat
         for item in mal_res.get('data', []):
             if 'mal_id' in item:
                 mal_ids.append(item['mal_id'])

--- a/plugin.video.otaku/resources/lib/endpoints/mal.py
+++ b/plugin.video.otaku/resources/lib/endpoints/mal.py
@@ -5,7 +5,7 @@ from resources.lib.ui import client, control
 
 
 class Mal:
-    _BASE_URL = "https://api.jikan.moe/v4"
+    _BASE_URL = control.MAL_API_BASE_URL
 
     def update_calendar(self, page=1):
         days_of_week = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']

--- a/plugin.video.otaku/resources/lib/indexers/jikanmoe.py
+++ b/plugin.video.otaku/resources/lib/indexers/jikanmoe.py
@@ -14,7 +14,7 @@ class JikanAPI:
     _request_timestamps = []
 
     def __init__(self):
-        self.baseUrl = "https://api.jikan.moe/v4"
+        self.baseUrl = control.MAL_API_BASE_URL
 
     @classmethod
     def _throttle_3req_per_second(cls):

--- a/plugin.video.otaku/resources/lib/indexers/otaku.py
+++ b/plugin.video.otaku/resources/lib/indexers/otaku.py
@@ -10,7 +10,7 @@ from resources.lib import indexers
 
 class OtakuAPI:
     def __init__(self):
-        self.baseUrl = "https://api.jikan.moe/v4"
+        self.baseUrl = control.MAL_API_BASE_URL
         # Simkl API setup
         api_info = database.get_info('Simkl')
         self.simklClientID = api_info['client_id']

--- a/plugin.video.otaku/resources/lib/indexers/otaku_next_up.py
+++ b/plugin.video.otaku/resources/lib/indexers/otaku_next_up.py
@@ -20,7 +20,7 @@ class Otaku_Next_Up_API:
         # Kitsu API setup
         self.kitsuBaseUrl = "https://kitsu.io/api/edge"
         # Jikan API setup (MAL)
-        self.baseUrl = "https://api.jikan.moe/v4"
+        self.baseUrl = control.MAL_API_BASE_URL
 
     def get_kitsu_id(self, mal_id):
         meta_ids = database.get_mappings(mal_id, 'mal_id')

--- a/plugin.video.otaku/resources/lib/ui/control.py
+++ b/plugin.video.otaku/resources/lib/ui/control.py
@@ -71,6 +71,12 @@ CONTEXT_ADDON = xbmcaddon.Addon(CONTEXT_ADDON_ID)
 CONTEXT_ADDON_PATH = CONTEXT_ADDON.getAddonInfo('path')
 infoDB = os.path.join(CONTEXT_ADDON_PATH, 'info.db')
 
+# — External API endpoints —
+# Jikan v4-schema-compatible MAL metadata provider. Centralized here so a
+# future provider swap (e.g. Jikan -> Tenrai) is a one-line change instead
+# of a multi-file find/replace.
+MAL_API_BASE_URL = "https://api.tenrai.org/v1"
+
 # — Database files —
 cacheFile = os.path.join(dataPath, 'cache.db')
 searchHistoryDB = os.path.join(dataPath, 'search.db')


### PR DESCRIPTION
The "Search" feature is currently failing and returning a 504 due to the `jikan` api being deprecated on October 1st 2026. 

### Problem
Current calls to MAL utilizes the free open source `jikan` api which will be deprecated. There is an alternative source called `tenrai` for the api connections to MAL. `Tenrai` is funcitonally the exact same as `Jikan` this is swapping the base path URLS to utilize the new api as well as centralizing the calls to a single variable.

```python
warning: OTAKU (22): Jikan request failed: https://api.jikan.moe/v4/anime
AttributeError: 'NoneType' object has no attribute 'get'
  → OtakuBrowser.py, line 77, in _flatten_mal_data_items
```

### Fix
Add an constant variable for the basepath within the `control.py`
- control.py:78          MAL_API_BASE_URL = "https://api.tenrai.org/v1"

Updated basepaths in the following six locations to use the constant variable.
- OtakuBrowser.py:41          _BASE_URL = control.MAL_API_BASE_URL
- MalBrowser.py:40            _BASE_URL = control.MAL_API_BASE_URL
- endpoints/mal.py:8          _BASE_URL = control.MAL_API_BASE_URL
- indexers/jikanmoe.py:17     self.baseUrl = control.MAL_API_BASE_URL
- indexers/otaku.py:13        self.baseUrl = control.MAL_API_BASE_URL
- indexers/otaku_next_up.py:23 self.baseUrl = control.MAL_API_BASE_URL

### Testing
Verified with my local system that it now correctly searches utilizing tenrai instead of jikan. Search returns with actual results and no longer an error.